### PR TITLE
Remove gateway from k8s Route Hosts

### DIFF
--- a/frontend/src/components/IstioWizards/K8sGRPCRouteHosts.tsx
+++ b/frontend/src/components/IstioWizards/K8sGRPCRouteHosts.tsx
@@ -1,51 +1,48 @@
 import * as React from 'react';
 import { Form, FormGroup, FormHelperText, HelperText, HelperTextItem, TextInput } from '@patternfly/react-core';
-import { K8sGatewaySelectorState } from './K8sGatewaySelector';
 import { isValid } from 'utils/Common';
 import { isK8sGatewayHostValid } from '../../utils/IstioConfigUtils';
 
 type Props = {
-  gateway?: K8sGatewaySelectorState;
   k8sRouteHosts: string[];
   onK8sRouteHostsChange: (valid: boolean, k8sRouteHosts: string[]) => void;
   valid: boolean;
 };
 
-export class K8sGRPCRouteHosts extends React.Component<Props> {
-  isK8sRouteHostsValid = (k8sRouteHosts: string[]): boolean => {
+export const K8sGRPCRouteHosts: React.FC<Props> = (props: Props) => {
+  const isK8sRouteHostsValid = (k8sRouteHosts: string[]): boolean => {
     // All k8s route hosts must be valid
     return k8sRouteHosts.every(host => {
       return isK8sGatewayHostValid(host);
     });
   };
 
-  render(): React.ReactNode {
-    const k8sRouteHosts = this.props.k8sRouteHosts.length > 0 ? this.props.k8sRouteHosts.join(',') : '';
-    return (
-      <Form isHorizontal={true}>
-        <FormGroup label="K8s GRPCRoute Hosts" fieldId="advanced-k8sRouteHosts">
-          <TextInput
-            value={k8sRouteHosts}
-            id="advanced-k8sRouteHosts"
-            name="advanced-k8sRouteHosts"
-            onChange={(_event, value) => {
-              const k8sRouteHosts = value.split(',');
-              const isValid = this.isK8sRouteHostsValid(k8sRouteHosts);
-              this.props.onK8sRouteHostsChange(isValid, k8sRouteHosts);
-            }}
-            validated={isValid(this.props.valid)}
-          />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>
-                {isValid(this.props.valid)
-                  ? 'The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma.'
-                  : "K8s Route hosts should be specified using FQDN format or '*.' format. IPs are not allowed."}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
-      </Form>
-    );
-  }
-}
+  const k8sRouteHosts = props.k8sRouteHosts.length > 0 ? props.k8sRouteHosts.join(',') : '';
+
+  return (
+    <Form isHorizontal={true}>
+      <FormGroup label="K8s GRPCRoute Hosts" fieldId="advanced-k8sRouteHosts">
+        <TextInput
+          value={k8sRouteHosts}
+          id="advanced-k8sRouteHosts"
+          name="advanced-k8sRouteHosts"
+          onChange={(_event, value) => {
+            const k8sRouteHosts = value.split(',');
+            const isValid = isK8sRouteHostsValid(k8sRouteHosts);
+            props.onK8sRouteHostsChange(isValid, k8sRouteHosts);
+          }}
+          validated={isValid(props.valid)}
+        />
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              {isValid(props.valid)
+                ? 'The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma.'
+                : "K8s Route hosts should be specified using FQDN format or '*.' format. IPs are not allowed."}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </Form>
+  );
+};

--- a/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
+++ b/frontend/src/components/IstioWizards/K8sGatewaySelector.tsx
@@ -19,25 +19,25 @@ import { isK8sGatewayHostValid } from '../../utils/IstioConfigUtils';
 import { serverConfig } from '../../config';
 
 type Props = {
-  serviceName: string;
-  hasGateway: boolean;
   gateway: string;
+  hasGateway: boolean;
   k8sGateways: string[];
   k8sRouteHosts: string[];
   onGatewayChange: (valid: boolean, gateway: K8sGatewaySelectorState) => void;
+  serviceName: string;
 };
 
 export type K8sGatewaySelectorState = {
   addGateway: boolean;
-  gwHosts: string;
-  gwHostsValid: boolean;
-  newGateway: boolean;
-  selectedGateway: string;
-  gatewayClass: string;
   // @TODO add Mesh is not supported yet
   addMesh: boolean;
-  port: number;
+  gatewayClass: string;
+  gwHosts: string;
+  gwHostsValid: boolean;
   isOpen: boolean;
+  newGateway: boolean;
+  port: number;
+  selectedGateway: string;
 };
 
 enum K8sGatewayForm {
@@ -61,21 +61,16 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
       gatewayClass: serverConfig?.gatewayAPIClasses[0]?.className,
       addMesh: false,
       port: 80,
-      isOpen: false,
+      isOpen: false
     };
   }
 
-  onToggleClick = () => {
-    this.setState((prevState) => ({isOpen: !prevState.isOpen}));
-  }
+  onToggleClick = (): void => {
+    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+  };
 
-  toggleMenu = (toggleRef: React.Ref<any>, label: string, isDisabled = false) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={this.onToggleClick}
-      isExpanded={this.state.isOpen}
-      isDisabled={isDisabled}
-    >
+  toggleMenu = (toggleRef: React.Ref<any>, label: string, isDisabled = false): React.ReactNode => (
+    <MenuToggle ref={toggleRef} onClick={this.onToggleClick} isExpanded={this.state.isOpen} isDisabled={isDisabled}>
       {label}
     </MenuToggle>
   );
@@ -87,7 +82,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
     });
   };
 
-  onFormChange = (component: K8sGatewayForm, value: string) => {
+  onFormChange = (component: K8sGatewayForm, value: string): void => {
     switch (component) {
       case K8sGatewayForm.SWITCH:
         this.setState(
@@ -120,7 +115,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
         this.setState(
           {
             selectedGateway: value,
-            isOpen: false,
+            isOpen: false
           },
           () => this.props.onGatewayChange(this.isGatewayValid(), this.state)
         );
@@ -143,17 +138,17 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
     return this.state.gwHostsValid;
   };
 
-  onChangeGatewayClass = (_event, value) => {
+  onChangeGatewayClass = (gatewayClass: string): void => {
     this.setState(
       {
-        gatewayClass: value,
-        isOpen: false,
+        gatewayClass: gatewayClass,
+        isOpen: false
       },
       () => this.props.onGatewayChange(this.isGatewayValid(), this.state)
     );
   };
 
-  render() {
+  render(): React.ReactNode {
     return (
       <Form isHorizontal={true}>
         <FormGroup label="Add K8s API Gateway" fieldId="gatewaySwitch">
@@ -166,6 +161,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
           />
           <span>{wizardTooltip(GATEWAY_TOOLTIP)}</span>
         </FormGroup>
+
         {this.state.addGateway && (
           <>
             <FormGroup fieldId="selectGateway">
@@ -177,6 +173,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                 isChecked={!this.state.newGateway}
                 onChange={() => this.onFormChange(K8sGatewayForm.SELECT, 'false')}
               />
+
               <Radio
                 id="createGateway"
                 name="selectGateway"
@@ -186,6 +183,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                 onChange={() => this.onFormChange(K8sGatewayForm.SELECT, 'true')}
               />
             </FormGroup>
+
             {!this.state.newGateway && (
               <FormGroup fieldId="selectGateway" label="K8sGateway">
                 {this.props.k8sGateways.length > 0 && (
@@ -193,11 +191,13 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                     id="selectGateway"
                     isOpen={this.state.isOpen}
                     selected={this.state.selectedGateway}
-                    onSelect={(_event, k8sGateway) => this.onFormChange(K8sGatewayForm.GATEWAY_SELECTED, k8sGateway as string)}
+                    onSelect={(_event, k8sGateway) =>
+                      this.onFormChange(K8sGatewayForm.GATEWAY_SELECTED, k8sGateway as string)
+                    }
                     onOpenChange={(isOpen: boolean) => {
-                      this.setState({isOpen});
+                      this.setState({ isOpen });
                     }}
-                    toggle={(toggleRef) =>
+                    toggle={toggleRef =>
                       this.toggleMenu(
                         toggleRef,
                         this.state.selectedGateway,
@@ -218,19 +218,20 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                 {this.props.k8sGateways.length === 0 && <>There are no K8s API gateways to select.</>}
               </FormGroup>
             )}
+
             {this.state.newGateway && (
               <>
                 {serverConfig.gatewayAPIClasses.length > 1 && (
                   <FormGroup label="Gateway Class" fieldId="gatewayClass">
                     <Select
-                      isOpen = {this.state.isOpen}
+                      isOpen={this.state.isOpen}
                       selected={this.state.gatewayClass}
-                      onSelect={this.onChangeGatewayClass}
+                      onSelect={(_event, gatewayClass) => this.onChangeGatewayClass(gatewayClass as string)}
                       id="gatewayClass"
                       onOpenChange={(isOpen: boolean) => {
-                        this.setState({isOpen});
+                        this.setState({ isOpen });
                       }}
-                      toggle={(toggleRef) => this.toggleMenu(toggleRef, this.state.gatewayClass)}
+                      toggle={toggleRef => this.toggleMenu(toggleRef, this.state.gatewayClass)}
                       shouldFocusToggleOnSelect
                     >
                       <SelectList>
@@ -242,7 +243,8 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                       </SelectList>
                     </Select>
                   </FormGroup>
-                  )}
+                )}
+
                 <FormGroup fieldId="gwPort" label="Port">
                   <TextInput
                     id="gwPort"
@@ -253,6 +255,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                     onChange={(_event, value) => this.onFormChange(K8sGatewayForm.PORT, value)}
                   />
                 </FormGroup>
+
                 <FormGroup fieldId="gwHosts" label="K8s API Gateway Hosts">
                   <TextInput
                     id="gwHosts"
@@ -262,6 +265,7 @@ export class K8sGatewaySelector extends React.Component<Props, K8sGatewaySelecto
                     onChange={(_event, value) => this.onFormChange(K8sGatewayForm.GW_HOSTS, value)}
                     validated={isValid(this.state.gwHostsValid)}
                   />
+
                   <FormHelperText>
                     <HelperText>
                       <HelperTextItem>

--- a/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
+++ b/frontend/src/components/IstioWizards/K8sRouteHosts.tsx
@@ -1,51 +1,48 @@
 import * as React from 'react';
 import { Form, FormGroup, FormHelperText, HelperText, HelperTextItem, TextInput } from '@patternfly/react-core';
-import { K8sGatewaySelectorState } from './K8sGatewaySelector';
 import { isValid } from 'utils/Common';
 import { isK8sGatewayHostValid } from '../../utils/IstioConfigUtils';
 
 type Props = {
-  valid: boolean;
   k8sRouteHosts: string[];
-  gateway?: K8sGatewaySelectorState;
   onK8sRouteHostsChange: (valid: boolean, k8sRouteHosts: string[]) => void;
+  valid: boolean;
 };
 
-export class K8sRouteHosts extends React.Component<Props> {
-  isK8sRouteHostsValid = (k8sRouteHosts: string[]): boolean => {
+export const K8sRouteHosts: React.FC<Props> = (props: Props) => {
+  const isK8sRouteHostsValid = (k8sRouteHosts: string[]): boolean => {
     // All k8s route hosts must be valid
     return k8sRouteHosts.every(host => {
       return isK8sGatewayHostValid(host);
     });
   };
 
-  render() {
-    const k8sRouteHosts = this.props.k8sRouteHosts.length > 0 ? this.props.k8sRouteHosts.join(',') : '';
-    return (
-      <Form isHorizontal={true}>
-        <FormGroup label="K8s HTTPRoute Hosts" fieldId="advanced-k8sRouteHosts">
-          <TextInput
-            value={k8sRouteHosts}
-            id="advanced-k8sRouteHosts"
-            name="advanced-k8sRouteHosts"
-            onChange={(_event, value) => {
-              const k8sRouteHosts = value.split(',');
-              const isValid = this.isK8sRouteHostsValid(k8sRouteHosts);
-              this.props.onK8sRouteHostsChange(isValid, k8sRouteHosts);
-            }}
-            validated={isValid(this.props.valid)}
-          />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem>
-                {isValid(this.props.valid)
-                  ? 'The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma.'
-                  : "K8s Route hosts should be specified using FQDN format or '*.' format. IPs are not allowed."}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
-      </Form>
-    );
-  }
-}
+  const k8sRouteHosts = props.k8sRouteHosts.length > 0 ? props.k8sRouteHosts.join(',') : '';
+
+  return (
+    <Form isHorizontal={true}>
+      <FormGroup label="K8s HTTPRoute Hosts" fieldId="advanced-k8sRouteHosts">
+        <TextInput
+          value={k8sRouteHosts}
+          id="advanced-k8sRouteHosts"
+          name="advanced-k8sRouteHosts"
+          onChange={(_event, value) => {
+            const k8sRouteHosts = value.split(',');
+            const isValid = isK8sRouteHostsValid(k8sRouteHosts);
+            props.onK8sRouteHostsChange(isValid, k8sRouteHosts);
+          }}
+          validated={isValid(props.valid)}
+        />
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              {isValid(props.valid)
+                ? 'The route hosts to which traffic is being sent. Enter one or multiple hosts separated by comma.'
+                : "K8s Route hosts should be specified using FQDN format or '*.' format. IPs are not allowed."}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </Form>
+  );
+};

--- a/frontend/src/components/IstioWizards/ServiceWizard.tsx
+++ b/frontend/src/components/IstioWizards/ServiceWizard.tsx
@@ -281,7 +281,7 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
         gatewayClass: '',
         addMesh: false,
         port: 80,
-        isOpen: false,
+        isOpen: false
       };
 
       if (hasGateway(this.props.virtualServices)) {
@@ -1098,7 +1098,6 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
                       <K8sRouteHosts
                         valid={this.state.valid.k8sRouteHosts}
                         k8sRouteHosts={this.state.k8sRouteHosts}
-                        gateway={this.state.gateway}
                         onK8sRouteHostsChange={this.onK8sRouteHosts}
                       />
                     </div>
@@ -1110,7 +1109,6 @@ export class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWi
                       <K8sGRPCRouteHosts
                         valid={this.state.valid.k8sRouteHosts}
                         k8sRouteHosts={this.state.k8sRouteHosts}
-                        gateway={this.state.gateway}
                         onK8sRouteHostsChange={this.onK8sRouteHosts}
                       />
                     </div>


### PR DESCRIPTION
Changes of this PR:
- Fix lint issues
- Convert simple React classes into hooks
- Remove gateway properties from k8sGRPCRouteHosts and k8sRouteHosts